### PR TITLE
#86 Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ mksnap/*
 !mksnap/**/*.sh
 global.config
 connections (copy).config
+build (copy).sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,65 +1,96 @@
 import scala.sys.process._
 
-enablePlugins(DebianPlugin,JavaAppPackaging)
+fork := true
 
-// scalacOptions += "-Ylog-classpath"
-
-name := "dbtarzan"
-
-version := "1.19"
-
-maintainer := "Andrea Ferrandi"
-
-scalaVersion := "2.12.7"
-
-mainClass in Compile := Some("dbtarzan.gui.Main")
-
-scalaSource in Compile := baseDirectory.value / "src"
-
-scalaSource in Test := baseDirectory.value / "test"
-
-scalacOptions in Compile ++= Seq("-Ywarn-unused:imports")
-scalacOptions in Compile --= Seq("-Xfatal-warnings")
-libraryDependencies ++= Seq(
+lazy val standardLibraries = Seq(
   "io.spray" %%  "spray-json" % "1.3.4",
   "org.scalatest" % "scalatest_2.12" % "3.0.5" % "test",
-  "org.scalafx" %% "scalafx" % "8.+",
+  "org.scalafx" %% "scalafx" % "11-R16",
   "com.typesafe.akka" %% "akka-actor" % "2.5.11",
   "com.h2database" % "h2" % "1.4.197"
 )
 
-unmanagedJars in Compile += Attributed.blank(
-    file(scala.util.Properties.javaHome) / "lib" / "ext" / "jfxrt.jar")
-    
-fork := true
 
-/* debian package */
-packageSummary := "DBTarzan Debian Package"
-packageDescription := "DBTarzan, the database browser"
-debianPackageDependencies in Debian ++= Seq("openjdk-8-jre")
-bashScriptExtraDefines += """addApp "--configPath=$HOME/.config/dbtarzan -Djdk.gtk.version=2""""
+lazy val commonConfiguration = Seq(
+  name := "dbtarzan",
 
+  maintainer := "Andrea Ferrandi",
 
-lazy val packageMacOS = taskKey[Unit]("Packages MacOS app")
-packageMacOS := {
-  val macOsDir = baseDirectory.value / "macosx"
-  "macosx/package.sh "+macOsDir+" "+version.value !
+  version := "1.20",
+
+  scalaVersion := "2.12.8",
+
+  mainClass in Compile := Some("dbtarzan.gui.Main"),
+
+  scalaSource in Compile := baseDirectory.value / ".." / "src",
+
+  scalaSource in Test := baseDirectory.value / ".." / "test",
+
+  resourceDirectory in Compile := baseDirectory.value / ".." / "src" / "main" / "resources",
+
+  resourceDirectory in Test := baseDirectory.value / ".." / "src" / "test" / "resources",
+
+  scalacOptions in Compile ++= Seq("-Ywarn-unused:imports"),
+  scalacOptions in Compile --= Seq("-Xfatal-warnings"),
+  assemblyMergeStrategy in assembly := {
+    case "module-info.class" => MergeStrategy.discard
+    case x => {
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(x)
+    }
+  },
+// scalacOptions += "-Ylog-classpath"
+  maintainer := "Andrea Ferrandi <ferrandi.andrea@gmail.com>",
+  packageSummary := "DBTarzan Package",
+  packageDescription := "DBTarzan, the database browser"
+
+) 
+
+def buildProject(name: String) = {
+  val javaFXModules = Seq("base", "controls", "graphics", "media")
+  Project(name, file(s"prj${name}"))
+    .settings(commonConfiguration)
+    .settings(
+      libraryDependencies ++= standardLibraries ++ javaFXModules.map( module => 
+        "org.openjfx" % s"javafx-$module" % "11" classifier name
+      )
+    )
 }
+
+
+lazy val linux = buildProject("linux")
+    .settings(Seq(
+      debianPackageDependencies in Debian ++= Seq("openjdk-11-jre"),
+      bashScriptExtraDefines += """addApp "--configPath=$HOME/.config/dbtarzan -Djdk.gtk.version=2""""
+    ))
+    .enablePlugins(DebianPlugin, JavaAppPackaging)
+    
+lazy val win = buildProject("win")
+
+lazy val mac = buildProject("mac")
 
 lazy val packageWin = taskKey[Unit]("Packages Windows app")
 packageWin := {
   val rootDir = baseDirectory.value
+  (win/assembly).value // dependency
   "mkwin/packageexe.sh "+rootDir+" "+version.value !
+}
+
+lazy val packageMacOS = taskKey[Unit]("Packages MacOS app")
+packageMacOS := {
+  val macOsDir = baseDirectory.value / "macosx"
+  (mac/assembly).value // dependency
+  "macosx/package.sh "+macOsDir+" "+version.value !
 }
 
 lazy val packageSnap = taskKey[Unit]("Packages Snap")
 packageSnap := {
   val rootDir = baseDirectory.value
+  (linux/assembly).value // dependency
   "mksnap/create.sh "+rootDir+" "+version.value !
 }
 
 addCommandAlias("packageAll", 
-	"; assembly " + 
 	"; debian:packageBin" +
   "; packageWin" +
   "; packageMacOS" +

--- a/macosx/package.sh
+++ b/macosx/package.sh
@@ -5,7 +5,7 @@ rm -r $DIR/DBTarzan-*.app*
 rm $DIR/dbtarzan-assembly-*.jar
 # create app
 APP=DBTarzan-$VERSION.app
-cp $DIR/../target/scala-2.12/dbtarzan-assembly-$VERSION.jar $DIR
+cp $DIR/../prjmac/target/scala-2.12/dbtarzan-assembly-$VERSION.jar $DIR
 (cd $DIR; jar2app dbtarzan-assembly-$VERSION.jar -n "DBTarzan-$VERSION" -i monkey-face-cartoon_256x256.icns -j "-DconfigPath=\$HOME/Library/ApplicationSupport/dbtarzan" -e universalJavaApplicationStub)
 # fix executable (https://github.com/tofi86/universalJavaApplicationStub)
 cp $DIR/universalJavaApplicationStub $DIR/$APP/Contents/MacOS

--- a/mksnap/create.sh
+++ b/mksnap/create.sh
@@ -6,8 +6,9 @@ cp snapcraft.mod snapcraft.yaml
 sed -i "s/VERSION/$VERSION/g" snapcraft.yaml
 rm dbtarzan_$VERSION.0_amd64.snap
 find . -type f -name dbtarzan-assembly* -delete
-cp ../target/scala-2.12/dbtarzan-assembly-$VERSION.jar .
-cp ../target/scala-2.12/dbtarzan-assembly-$VERSION.jar $SNAPDIR/source/
+ASSEMBLY=../prjlinux/target/scala-2.12/dbtarzan-assembly-$VERSION.jar
+cp $ASSEMBLY .
+cp $ASSEMBLY $SNAPDIR/source/
 snapcraft clean
 snapcraft build
 find parts/java -type f -name dbtarzan-assembly* -delete

--- a/mksnap/install.sh
+++ b/mksnap/install.sh
@@ -6,4 +6,5 @@ snap remove dbtarzan
 snap install dbtarzan_$VERSION.0_amd64.snap --devmode
 mkdir ~/snap/dbtarzan/common
 cp $ROOTDIR/connections.config ~/snap/dbtarzan/common/
+cp $ROOTDIR/global.config ~/snap/dbtarzan/common/
 cd -

--- a/mksnap/snapcraft.mod
+++ b/mksnap/snapcraft.mod
@@ -16,33 +16,17 @@ apps:
         FONTCONFIG_PATH: $SNAP/etc/fonts/config.d
         FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf    
         # Standard libraries for Java
-        JAVA_HOME: $SNAP/usr/lib/jvm/java-8-openjdk-amd64
-        PATH: $SNAP/usr/lib/jvm/java-8-openjdk-amd64/bin:$SNAP/usr/lib/jvm/java-8-openjdk-amd64/jre/bin:$PATH
+        JAVA_HOME: $SNAP/usr/lib/jvm/java-11-openjdk-amd64
+        PATH: $SNAP/usr/lib/jvm/java-11-openjdk-amd64/bin:$SNAP/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:$PATH
         LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/
     plugs: [home, unity7, x11, wayland, network]
 
 parts:
-  libopenjfxjava:
-    plugin: dump 
-    source-type: deb
-    source: http://no.archive.ubuntu.com/ubuntu/pool/universe/o/openjfx/libopenjfx-java_8u161-b12-1ubuntu2_all.deb
-
-  libopenjfxjni:
-    plugin: dump 
-    source-type: deb
-    source: http://no.archive.ubuntu.com/ubuntu/pool/universe/o/openjfx/libopenjfx-jni_8u161-b12-1ubuntu2_amd64.deb
-    stage-packages: [libasound2, libavcodec57, libavformat57, libc6, libcairo2, libfreetype6, libgcc1, libgdk-pixbuf2.0-0, libgl1, libglib2.0-0, libgtk2.0-0, libjpeg8, libpango-1.0-0, libpangoft2-1.0-0, libstdc++6, libx11-6, libxml2, libxslt1.1, libxtst6]
-  
-  openjfx:
-    plugin: dump 
-    source-type: deb
-    source: http://no.archive.ubuntu.com/ubuntu/pool/universe/o/openjfx/openjfx_8u161-b12-1ubuntu2_amd64.deb
-  
   # one part for the java libraries and dependencies, one for the jar itself
   java:
     plugin: dump 
     # without libcamberra... it complains that canberra-gtk is not available. 
-    stage-packages: [libc6, openjdk-8-jre, zlib1g, fonts-ubuntu, libcanberra-gtk-module, libcanberra-gtk3-module]
+    stage-packages: [libc6, openjdk-11-jre, zlib1g, fonts-ubuntu, libcanberra-gtk-module, libcanberra-gtk3-module]
   dbtarzan:
     source: source/
     plugin: dump

--- a/mkwin/launch4j_config.mod
+++ b/mkwin/launch4j_config.mod
@@ -18,7 +18,7 @@
     <path></path>
     <bundledJre64Bit>false</bundledJre64Bit>
     <bundledJreAsFallback>false</bundledJreAsFallback>
-    <minVersion>1.8.0</minVersion>
+    <minVersion>11</minVersion>
     <maxVersion></maxVersion>
     <jdkPreference>preferJre</jdkPreference>
     <runtimeBits>64/32</runtimeBits>

--- a/mkwin/packageexe.sh
+++ b/mkwin/packageexe.sh
@@ -4,7 +4,7 @@ WINDIR=$ROOTDIR/mkwin
 VERSION=$2
 echo "ROOTDIR $ROOTDIR WINDIR $WINDIR VERSION $VERSION"
 cp $WINDIR/launch4j_config.mod $WINDIR/launch4j_config.xml
-JARFILE="$ROOTDIR/target/scala-2.12/dbtarzan-assembly-$VERSION.jar"
+JARFILE="$ROOTDIR/prjwin/target/scala-2.12/dbtarzan-assembly-$VERSION.jar"
 OUTFILE="$WINDIR/dbtarzan_$VERSION.exe" 
 ICONFILE="$WINDIR/monkey-face-cartoon.ico"
 JARESCAPED="${JARFILE//\//\\\/}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Uses Java 11 to compile DBTarzan #86 


* **What is the current behavior?** (You can also link to an open issue here)
Builds a Java 8 Jar and creates setup files for Linux, Windows and Mac which contain it


* **What is the new behavior (if this is a feature change)?**
SInce JavaFX is now in form of Jar files build.sbt contains 3 projects that produce fat jar files for the 3 operating systems and from them produce the setup files


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, DBTarzan cannot be built for versions before Java 11



* **Other information**:
**buld.sbt**. 3 projects based on the same source files, 3 setup files (publish...) based on the fat jars produced by the 3 projects.
**macosx/package.sh**: gets the fat jar from the new prjmac project directory
** mksnap/create.sh**: gets the fat jar from the new prjlinux project directory
**mksnap/install.sh**: bases DBTarzan on existing global.config files, if they exist
**mksnap/snapcraft.mod**: removed dependencies on downloaded deb files and base itself on Java 11
**launch4j_config.mod **: requires Java 11
**mkwin/packageexe.sh**:gets the fat jar from the new prjwin project directory 
