### PR TITLE
#60 dbl-clicking a row or pressing enter opens the vertical row view

### DIFF
--- a/src/main/scala/dbtarzan/gui/BrowsingTable.scala
+++ b/src/main/scala/dbtarzan/gui/BrowsingTable.scala
@@ -42,6 +42,10 @@ class BrowsingTable(dbActor : ActorRef, guiActor : ActorRef, structure : DBTable
     })
   }
   table.setRowClickListener(row => openRowDisplay(row))
+  table.setRowDoubleClickListener(row => {
+    switchRowDetailsView()
+    openRowDisplay(row)
+  })
 
   splitter.splitPanelWithoutRowDetailsView()
   private val progressBar = new TableProgressBar(removeProgressBar)

--- a/src/main/scala/dbtarzan/gui/Table.scala
+++ b/src/main/scala/dbtarzan/gui/Table.scala
@@ -3,6 +3,7 @@ package dbtarzan.gui
 import akka.actor.ActorRef
 import dbtarzan.db._
 import dbtarzan.gui.table._
+import dbtarzan.gui.util.JFXUtil
 import dbtarzan.localization.Localization
 import dbtarzan.messages.{Logger, _}
 import scalafx.Includes._
@@ -99,9 +100,12 @@ class Table(dbActor: ActorRef, guiActor : ActorRef, queryId : QueryId, dbTable :
       case ex : Exception => log.error(localization.errorDisplayingRows, ex)
     }
 
-  def setRowClickListener(listener : Row => Unit) : Unit = {
+  def setRowClickListener(listener : Row => Unit) : Unit =
     rowClickListener = Some(listener)
-  }
+
+  def setRowDoubleClickListener(listener: Row => Unit) : Unit =
+    JFXUtil.onAction(table, (row: CheckedRow, clicked: Boolean) => listener(row.row))
+
 
   private def displayKeyForFields(headingsTexts : List[HeadingTextAndIcon]) : Unit =
     headingsTexts.foreach(ht => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [V] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
double-click or pressing enter on a row make the row virtual view appear


* **What is the current behavior?** (You can also link to an open issue here)
Only Ctrl-R make the virtual row appea


* **What is the new behavior (if this is a*  feature change)?**
More possibility to show the row virtual view 



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
