### PR TITLE
#147 show foreignkeys rows number

### DIFF
--- a/src/main/scala/dbtarzan/db/DBTypes.scala
+++ b/src/main/scala/dbtarzan/db/DBTypes.scala
@@ -52,7 +52,7 @@ Contains:
 - the foreign key
 - the rows checked by the user in the original table
  */
-case class FollowKey(columns : List[Field], key : ForeignKey, rows : List[Row])
+case class FollowKey(columns : List[Field], key : ForeignKey, rows : Option[List[Row]])
 /* the foreign keys involving a table, with the table */
 case class ForeignKeysForTable(tableId : TableId, keys : ForeignKeys)
 /* all the foreign keys for all tables in the database */

--- a/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
+++ b/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
@@ -162,7 +162,7 @@ class DatabaseActor(
     val columnsFollow = cache.cachedFields(tableName, core.columnsLoader.columnNames(tableName))
     guiActor ! ResponseColumnsFollow(qry.tableId, qry.follow, columnsFollow, core.attributes)
   }, logError)
-  
+
   private def queryIndexes(qry: QueryIndexes) : Unit = coreHandler.withCore(qry.queryId, core => {
     val tableName = qry.queryId.tableId.tableName
     val indexes = cache.cachedIndexes(tableName, core.indexesLoader.indexes(tableName))
@@ -177,8 +177,8 @@ class DatabaseActor(
   }, e => guiActor ! ErrorRows(qry.queryId, e))
 
   private def queryForeignKeyRowsNumber(qry: QueryForeignKeyRowsNumber): Unit = coreHandler.withCore(qry.queryId, core => {
-    val tableName = qry.queryId.tableId.tableName
-    val columnsFollow = cache.cachedFields(tableName, core.columnsLoader.columnNames(tableName))
+    val toTableName = qry.follow.key.to.table.tableName
+    val columnsFollow = cache.cachedFields(toTableName, core.columnsLoader.columnNames(toTableName))
     val followTable = ForeignKeyMapper.toFollowTable(qry.follow, columnsFollow, qry.structure.attributes)
     val sql = SqlBuilder.buildCountSql(followTable)
     val queryTimeouts = calcQueryTimeouts(core)
@@ -190,7 +190,7 @@ class DatabaseActor(
   private def calcQueryTimeouts(core: DatabaseCore) = {
     core.limits.queryTimeoutInSeconds.map(_.seconds).getOrElse(10 seconds)
   }
-  
+
   private def queryColumnsForForeignKeys(qry: QueryColumnsForForeignKeys) : Unit = coreHandler.withCore(qry.tableId, core => {
     val tableName = qry.tableId.tableName
     val columns = cache.cachedFields(tableName, core.columnsLoader.columnNames(tableName))

--- a/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
+++ b/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
@@ -1,20 +1,17 @@
 package dbtarzan.db.actor
 
-import org.apache.pekko.actor.{Actor, ActorRef}
 import dbtarzan.config.connections.ConnectionData
-import dbtarzan.config.password.{EncryptionKey, Password}
-import dbtarzan.db.{ForeignKey, *}
+import dbtarzan.config.password.EncryptionKey
 import dbtarzan.db.foreignkeys.{ForeignKeyMapper, VirtualForeignKeyToForeignKey}
 import dbtarzan.db.sql.SqlBuilder
-import dbtarzan.db.util.ExceptionToText
+import dbtarzan.db.*
 import dbtarzan.localization.Localization
 import dbtarzan.log.actor.Logger
-import dbtarzan.messages.DatabaseIdUtil.databaseIdText
 import dbtarzan.messages.*
+import dbtarzan.messages.DatabaseIdUtil.databaseIdText
+import org.apache.pekko.actor.{Actor, ActorRef}
 
 import java.nio.file.Path
-import java.sql.{Connection, SQLException}
-import java.time.LocalDateTime
 import scala.collection.mutable
 import scala.concurrent.duration.*
 import scala.language.postfixOps
@@ -46,7 +43,7 @@ class DatabaseActor(
       val foreignFromFile = new DatabaseForeignKeysFromFile(databaseId, SimpleDatabaseId(data.name), localization, keyFilesDirPath, log)
       foreignFromFile.loadForeignKeysFromFile()
     })
-    mutable.HashMap(keysForAllSimpleDatabases.toSeq*)
+    mutable.HashMap(keysForAllSimpleDatabases *)
   }
 
   private def logError(e: Exception) : Unit = log.error("dbWorker", e)
@@ -131,7 +128,7 @@ class DatabaseActor(
   }
 
   private def schemaIds(cores: List[DatabaseCore]): List[SchemaId] = {
-    cores.flatMap(core => core.schemasLoader.schemasNames().map(schemaName => SchemaId(databaseId, core.simpleDatabaseId, schemaName))).toList
+    cores.flatMap(core => core.schemasLoader.schemasNames().map(schemaName => SchemaId(databaseId, core.simpleDatabaseId, schemaName)))
   }
 
   private def querySchemas(qry: QuerySchemas) : Unit = coreHandler.withCores(cores => {
@@ -200,7 +197,7 @@ class DatabaseActor(
   private def queryPrimaryKeys(qry: QueryPrimaryKeys) : Unit = coreHandler.withCore(qry.queryId, core => {
     val tableName = qry.queryId.tableId.tableName
     val primaryKeys = cache.cachedPrimaryKeys(tableName, core.primaryKeysLoader.primaryKeys(tableName))
-    log.debug(s"Primary keys ${primaryKeys}")
+    log.debug(s"Primary keys $primaryKeys")
     guiActor ! ResponsePrimaryKeys(qry.queryId, qry.structure, primaryKeys)
   }, logError)
 
@@ -221,7 +218,7 @@ class DatabaseActor(
       log.error(localization.errorAFKAlreadyExisting(intersection))
   }
 
-  def queryOneRow(qry: QueryOneRow): Unit = coreHandler.withCore(qry.queryId, core => {
+  private def queryOneRow(qry: QueryOneRow): Unit = coreHandler.withCore(qry.queryId, core => {
     val queryTimeput = calcQueryTimeouts(core)
     core.queryLoader.query(SqlBuilder.buildSingleRowSql(qry.structure), 1, queryTimeput, None, qry.structure.columns, rows =>
       guiActor ! ResponseOneRow(qry.queryId, qry.structure, rows.rows.head)

--- a/src/main/scala/dbtarzan/db/foreignkeys/ForeignKeyMapper.scala
+++ b/src/main/scala/dbtarzan/db/foreignkeys/ForeignKeyMapper.scala
@@ -9,12 +9,17 @@ class ForeignKeyMapper(follow : FollowKey, newColumns : Fields, attributes : Que
 
 	private def toFollowTable() : DBTableStructure = {
 		try {
-			val fkRows = follow.rows.map(row => buildKeyValuesForRow(row))
-			val keyCriteria = ForeignKeyCriteria(fkRows, follow.key.to.fields.map(name => newColumns.fields.find(f => f.name.equalsIgnoreCase(name)).get))
+			val keyCriteria: Option[ForeignKeyCriteria] = follow.rows.map(buildCriteria)
 			val description = TableDescription(follow.key.to.table.tableName, Option(follow.key.from.table.tableName), None)
-			DBTableStructure(description, newColumns, Some(keyCriteria), None, None, attributes)
+			DBTableStructure(description, newColumns, keyCriteria, None, None, attributes)
 		} catch
 			case ex: Exception => throw  new Exception(s"Following to table with newColumns $newColumns and follow fields to ${follow.key.to.fields} got ", ex)
+	}
+
+	private def buildCriteria(row: List[Row]): ForeignKeyCriteria = {
+		val fkRows = row.map(row => buildKeyValuesForRow(row))
+		val keyCriteria = ForeignKeyCriteria(fkRows, follow.key.to.fields.map(name => newColumns.fields.find(f => f.name.equalsIgnoreCase(name)).get))
+		keyCriteria
 	}
 
 	/* has a foreignkey FK(keyfrom, keyto), the columns from */

--- a/src/main/scala/dbtarzan/db/foreignkeys/ForeignKeyMapper.scala
+++ b/src/main/scala/dbtarzan/db/foreignkeys/ForeignKeyMapper.scala
@@ -7,7 +7,7 @@ import dbtarzan.db.{ FollowKey, Fields, QueryAttributes, DBTableStructure, Table
 class ForeignKeyMapper(follow : FollowKey, newColumns : Fields, attributes : QueryAttributes) {
 	val mapNameToIndex: Map[String, Int] = follow.columns.map(_.name.toUpperCase).zipWithIndex.toMap
 
-	private def toFollowTable() : DBTableStructure = {
+	private def buildFollowTable() : DBTableStructure = {
 		try {
 			val keyCriteria: Option[ForeignKeyCriteria] = follow.rows.map(buildCriteria)
 			val description = TableDescription(follow.key.to.table.tableName, Option(follow.key.from.table.tableName), None)
@@ -17,8 +17,12 @@ class ForeignKeyMapper(follow : FollowKey, newColumns : Fields, attributes : Que
 	}
 
 	private def buildCriteria(row: List[Row]): ForeignKeyCriteria = {
+		def findForeignKeyToFieldInToTable(name: String) =
+			newColumns.fields.find(f => f.name.equalsIgnoreCase(name)).get
+
 		val fkRows = row.map(row => buildKeyValuesForRow(row))
-		val keyCriteria = ForeignKeyCriteria(fkRows, follow.key.to.fields.map(name => newColumns.fields.find(f => f.name.equalsIgnoreCase(name)).get))
+		val fkFields = follow.key.to.fields.map(findForeignKeyToFieldInToTable)
+		val keyCriteria = ForeignKeyCriteria(fkRows, fkFields)
 		keyCriteria
 	}
 
@@ -38,5 +42,5 @@ class ForeignKeyMapper(follow : FollowKey, newColumns : Fields, attributes : Que
 
 object ForeignKeyMapper {
 	def toFollowTable(follow : FollowKey, newColumns : Fields, attributes : QueryAttributes) : DBTableStructure = 
-		new ForeignKeyMapper(follow, newColumns, attributes).toFollowTable()
+		new ForeignKeyMapper(follow, newColumns, attributes).buildFollowTable()
 }

--- a/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyList.scala
+++ b/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyList.scala
@@ -23,7 +23,7 @@ class ForeignKeyList(queryId : QueryId, dbActor: ActorRef, localization : Locali
     text = ""
     editable = false
     wrapText = true
-    maxHeight = JFXUtil.averageCharacterHeight() * 6
+    maxHeight = JFXUtil.averageCharacterHeight() * 7
   }
   private val buttonRowsNumber = new ToggleButton() {
     text = localization.rowsNumber

--- a/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyList.scala
+++ b/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyList.scala
@@ -4,15 +4,14 @@ import dbtarzan.db.{ForeignKey, ForeignKeys}
 import dbtarzan.gui.interfaces.TControlBuilder
 import dbtarzan.gui.util.{ForeignKeyIcons, JFXUtil, TableIdLabel, TableUtil}
 import dbtarzan.localization.Localization
-import dbtarzan.messages.{QueryForeignKeyRowsNumber, QueryForeignKeys, QueryId, TLogger}
+import dbtarzan.messages.{QueryId, TLogger}
 import org.apache.pekko.actor.ActorRef
 import scalafx.Includes.*
-import scalafx.beans.property.{ObjectProperty, StringProperty}
 import scalafx.collections.ObservableBuffer
 import scalafx.scene.Parent
-import scalafx.scene.control.{Button, Label, SelectionMode, TableCell, TableColumn, TableView, TextArea, ToggleButton}
-import scalafx.scene.image.{Image, ImageView}
-import scalafx.scene.layout.{BorderPane, VBox}
+import scalafx.scene.control.{TableColumn, TableView, TextArea, ToggleButton}
+import scalafx.scene.image.Image
+import scalafx.scene.layout.BorderPane
 
 
 /**	foreign keys list */

--- a/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyListWithFilter.scala
+++ b/src/main/scala/dbtarzan/gui/browsingtable/ForeignKeyListWithFilter.scala
@@ -13,7 +13,7 @@ import scalafx.scene.layout.BorderPane
 
 /*	The list of database to choose from*/
 class ForeignKeyListWithFilter(queryId : QueryId, dbActor: ActorRef, log: Logger, localization : Localization) extends TControlBuilder {
-  private val foreignKeyList = new ForeignKeyList(localization, log)
+  private val foreignKeyList = new ForeignKeyList(queryId, dbActor, localization, log)
   private val filterText = new FilterText(dbActor ! QueryForeignKeysByPattern(queryId, _), localization)
   private val pane = new BorderPane {
     top = filterText.control
@@ -26,8 +26,14 @@ class ForeignKeyListWithFilter(queryId : QueryId, dbActor: ActorRef, log: Logger
   def setForeignKeysByPattern(foreignKeysByPattern: ForeignKeys): Unit =
     foreignKeyList.setForeignKeysByPattern(foreignKeysByPattern)
 
-  def onForeignKeySelected(useKey : (ForeignKey, Boolean)  => Unit) : Unit =
+  def onForeignKeyDoubleClicked(useKey : (ForeignKey, Boolean)  => Unit) : Unit =
+    foreignKeyList.onForeignKeyDoubleClicked(useKey)
+
+  def onForeignKeySelected(useKey : ForeignKey  => Unit) : Unit =
     foreignKeyList.onForeignKeySelected(useKey)
+
+  def showForeignKeyRowsNumber(foreignKey: ForeignKey, rowsNumber: Int) : Unit =
+    foreignKeyList.showForeignKeyRowsNumber(foreignKey, rowsNumber)
 
   def control : Parent = pane
 }

--- a/src/main/scala/dbtarzan/gui/database/TableTabs.scala
+++ b/src/main/scala/dbtarzan/gui/database/TableTabs.scala
@@ -62,6 +62,7 @@ class TableTabs(dbActor : ActorRef, guiActor : ActorRef, localization : Localiza
     case order : RequestOrderByEditor => tables.tableWithQueryId(order.queryId, _.startOrderByEditor())
     case rows : ResponseRows => createTabWith(rows.queryId, rows.structure, addRows(_, rows))
     case rowsNumber: ResponseRowsNumber => tables.tableWithQueryId(rowsNumber.queryId, showRowsNumber(_, rowsNumber))
+    case rowsNumber : ResponseForeignKeyRowsNumber => tables.tableWithQueryId(rowsNumber.queryId, showForeignKeyRowsNumber(_, rowsNumber))
     case errorRows : ErrorRows => tables.tableWithQueryId(errorRows.queryId, rowsError(_, errorRows))
     case oneRow : ResponseOneRow =>  tables.tableWithQueryId(oneRow.queryId, addOneRow(_, oneRow))
     case reloadQuery: ReloadQuery => tables.tableWithQueryId(reloadQuery.queryId, _.reloadQuery(reloadQuery.closeCurrentTab))
@@ -128,6 +129,8 @@ class TableTabs(dbActor : ActorRef, guiActor : ActorRef, localization : Localiza
   private def showRowsNumber(table: BrowsingTable, rowsNumber: ResponseRowsNumber): Unit =
     table.showRowsNumber(rowsNumber)
 
+  private def showForeignKeyRowsNumber(table: BrowsingTable, rowsNumber: ResponseForeignKeyRowsNumber): Unit =
+    table.showForeignKeyRowsNumber(rowsNumber)
 
   private def rowsError(table: BrowsingTable, error: ErrorRows) : Unit = {
     table.rowsError()

--- a/src/main/scala/dbtarzan/messages/DBMessages.scala
+++ b/src/main/scala/dbtarzan/messages/DBMessages.scala
@@ -1,7 +1,7 @@
 package dbtarzan.messages
 
 import org.apache.pekko.actor.ActorRef
-import dbtarzan.db.{VirtualalForeignKey, Composite, DBRowStructure, DBTableStructure, DatabaseId, FollowKey, TableId}
+import dbtarzan.db.{Composite, DBRowStructure, DBTableStructure, DatabaseId, FollowKey, ForeignKey, TableId, VirtualalForeignKey}
 
 
 case class OriginalQuery(queryId : QueryId, closeCurrentTab : Boolean)
@@ -23,6 +23,8 @@ case class QueryColumnsFollow(tableId: TableId, follow : FollowKey)
 case class QueryPrimaryKeys(queryId : QueryId, structure : DBTableStructure)
 
 case class QueryForeignKeys(queryId : QueryId, structure : DBTableStructure)
+
+case class QueryForeignKeyRowsNumber(queryId : QueryId, structure : DBTableStructure, follow : FollowKey)
 
 case class QueryForeignKeysByPattern(queryId : QueryId, pattern: String)
 

--- a/src/main/scala/dbtarzan/messages/GUIMessages.scala
+++ b/src/main/scala/dbtarzan/messages/GUIMessages.scala
@@ -54,6 +54,9 @@ case class ResponseIndexes(queryId : QueryId, indexes: Indexes)
 case class ResponseRowsNumber(queryId : QueryId, rowsNumber: Int)
   extends TWithQueryId
 
+case class ResponseForeignKeyRowsNumber(queryId: QueryId, foreignKey: ForeignKey, rowsNumber: Int)
+  extends TWithQueryId
+
 case class ResponseColumnsFollow(tableId: TableId,  follow : FollowKey, columns : Fields, queryAttributes : QueryAttributes) 
     extends TWithTableId
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ X] The commit message follows our guidelines
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When the toggle button is selected. clicking on a foreign key displays also the  number of the rows in the related table which are connected to the checked  rows. 


* **What is the current behavior?** (You can also link to an open issue here)

The  number of rows is not displayed


* **What is the new behavior (if this is a feature change)?**

The  number of rows is displayed when indicated by the toggle button.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
