### PR TITLE
#148 improve large texts performance

### DIFF
--- a/connections.config
+++ b/connections.config
@@ -14,7 +14,7 @@
     },
     "maxRows": null,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 300,
+    "maxFieldSize": null,
     "maxInClauseCount": 1000,
     "catalog": null
   },
@@ -33,7 +33,10 @@
     },
     "maxRows": null,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 300,
+    "maxFieldSize": {
+      "value": 300,
+      "leftSQLFunction": null
+    },
     "maxInClauseCount": 1000,
     "catalog": null
   },
@@ -49,7 +52,10 @@
     "identifierDelimiters": null,
     "maxRows": null,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 500,
+    "maxFieldSize": {
+      "value": 500,
+      "leftSQLFunction": null
+    },
     "maxInClauseCount": null,
     "catalog": null
   },
@@ -65,7 +71,10 @@
     "identifierDelimiters": null,
     "maxRows": null,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 500,
+    "maxFieldSize": {
+      "value": 500,
+      "leftSQLFunction": null
+    },
     "maxInClauseCount": null,
     "catalog": null
   },
@@ -138,7 +147,10 @@
     "identifierDelimiters": null,
     "maxRows": null,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 500,
+    "maxFieldSize": {
+      "value": 500,
+      "leftSQLFunction": null
+    },
     "maxInClauseCount": null,
     "catalog": null
   },
@@ -154,7 +166,10 @@
     "identifierDelimiters": null,
     "maxRows": 2000,
     "queryTimeoutInSeconds": null,
-    "maxFieldSize": 1000,
+    "maxFieldSize": {
+      "value": 1000,
+      "leftSQLFunction": null
+    },
     "maxInClauseCount": null,
     "catalog": null
   },

--- a/src/main/scala/dbtarzan/config/connections/ConnectionData.scala
+++ b/src/main/scala/dbtarzan/config/connections/ConnectionData.scala
@@ -1,7 +1,7 @@
 package dbtarzan.config.connections
 
 import dbtarzan.config.password.Password
-import dbtarzan.db.{IdentifierDelimiters, SchemaName}
+import dbtarzan.db.{IdentifierDelimiters, MaxFieldSize, SchemaName}
 
 
 /* JDBC configuration for a database */
@@ -29,7 +29,7 @@ case class ConnectionData(
    /* the max time a query can take in seconds */
    queryTimeoutInSeconds : Option[Int],
    /* to avoid slow queries because of very large fields values. In bytes */
-   maxFieldSize: Option[Int],
+   maxFieldSize: Option[MaxFieldSize],
    /* maximum amounts of elements in an in clause for this database */
    maxInClauseCount: Option[Int],
    /* the catalog of the database containing the data, used when the schema is not enough (table user n MySQL)  */

--- a/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
+++ b/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
@@ -1,7 +1,7 @@
 package dbtarzan.config.connections
 
-import dbtarzan.db.{CompositeId, IdentifierDelimiters, SchemaName}
-import grapple.json.{*, given}
+import dbtarzan.db.{CompositeId, IdentifierDelimiters, MaxFieldSize, SchemaName}
+import grapple.json.{JsonInput, JsonOutput, *, given}
 import dbtarzan.config.password.{*, given}
 import dbtarzan.config.connections.ConnectionData
 
@@ -11,13 +11,25 @@ given JsonInput[IdentifierDelimiters] with
 given JsonOutput[IdentifierDelimiters] with
   def write(u: IdentifierDelimiters): JsonObject = Json.obj("start" -> u.start.toString, "end" -> u.end.toString)
 
+given JsonInput[MaxFieldSize] with
+  def read(json: JsonValue): MaxFieldSize = MaxFieldSize(json("value").as[Int], json.readOption("leftFunction"))
+
+given JsonOutput[MaxFieldSize] with
+  def write(u: MaxFieldSize): JsonObject = Json.obj("value" -> u.value.toString, "leftFunction" -> u.leftFunction)
+
 given JsonInput[SchemaName] with
   def read(json: JsonValue): SchemaName = SchemaName(json.as[String])
 
 given JsonOutput[SchemaName] with
   def write(u: SchemaName): JsonValue = JsonString(u.schema)
 
-given JsonInput[ConnectionData] =
+given JsonInput[ConnectionData] = {
+  def readMaxFieldSizeOrInt(value: JsonValue)(using inputMaxFieldSize: JsonInput[MaxFieldSize])(using inputInt: JsonInput[Int]) = {
+    try
+     inputMaxFieldSize.read(value)
+    catch
+      case _ => MaxFieldSize(inputInt.read(value), None)    
+  }
   json =>
     ConnectionData(
       json.getString("jar"),
@@ -31,10 +43,11 @@ given JsonInput[ConnectionData] =
       json.readOption[IdentifierDelimiters]("identifierDelimiters"),
       json.readOption[Int]("maxRows"),
       json.readOption[Int]("queryTimeoutInSeconds"),
-      json.readOption[Int]("maxFieldSize"),
+      json.get("maxFieldSize").filter(JsonNull.!=).map(v => readMaxFieldSizeOrInt(v)),
       json.readOption[Int]("maxInClauseCount"),
       json.readOption[String]("catalog")
     )
+}
 
 
 given JsonOutput[ConnectionData] with

--- a/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
+++ b/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
@@ -15,7 +15,7 @@ given JsonInput[MaxFieldSize] with
   def read(json: JsonValue): MaxFieldSize = MaxFieldSize(json("value").as[Int], json.readOption("leftSQLFunction"))
 
 given JsonOutput[MaxFieldSize] with
-  def write(u: MaxFieldSize): JsonObject = Json.obj("value" -> u.value, "leftSQLFunction" -> u.lefSQLFunction)
+  def write(u: MaxFieldSize): JsonObject = Json.obj("value" -> u.value, "leftSQLFunction" -> u.leftSQLFunction)
 
 given JsonInput[SchemaName] with
   def read(json: JsonValue): SchemaName = SchemaName(json.as[String])

--- a/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
+++ b/src/main/scala/dbtarzan/config/connections/ConnectionDataJsonProtocol.scala
@@ -12,10 +12,10 @@ given JsonOutput[IdentifierDelimiters] with
   def write(u: IdentifierDelimiters): JsonObject = Json.obj("start" -> u.start.toString, "end" -> u.end.toString)
 
 given JsonInput[MaxFieldSize] with
-  def read(json: JsonValue): MaxFieldSize = MaxFieldSize(json("value").as[Int], json.readOption("leftFunction"))
+  def read(json: JsonValue): MaxFieldSize = MaxFieldSize(json("value").as[Int], json.readOption("leftSQLFunction"))
 
 given JsonOutput[MaxFieldSize] with
-  def write(u: MaxFieldSize): JsonObject = Json.obj("value" -> u.value, "leftFunction" -> u.leftFunction)
+  def write(u: MaxFieldSize): JsonObject = Json.obj("value" -> u.value, "leftSQLFunction" -> u.lefSQLFunction)
 
 given JsonInput[SchemaName] with
   def read(json: JsonValue): SchemaName = SchemaName(json.as[String])

--- a/src/main/scala/dbtarzan/db/QueryAttributes.scala
+++ b/src/main/scala/dbtarzan/db/QueryAttributes.scala
@@ -17,4 +17,4 @@ object QueryAttributes {
 	def none(): QueryAttributes = QueryAttributes(None, DBDefinition(None, None), None, Some(1000))
 }
 
-case class MaxFieldSize(value: Int, lefSQLFunction: Option[String])
+case class MaxFieldSize(value: Int, leftSQLFunction: Option[String])

--- a/src/main/scala/dbtarzan/db/QueryAttributes.scala
+++ b/src/main/scala/dbtarzan/db/QueryAttributes.scala
@@ -11,8 +11,10 @@ object IdentifierDelimitersValues {
 
 case class DBDefinition(schemaId : Option[SchemaId], catalog : Option[String])
 
-case class QueryAttributes(delimiters : Option[IdentifierDelimiters], definition : DBDefinition, maxFieldSize: Option[Int], maxInClauseCount: Option[Int])
+case class QueryAttributes(delimiters : Option[IdentifierDelimiters], definition : DBDefinition, maxFieldSize: Option[MaxFieldSize], maxInClauseCount: Option[Int])
 
 object QueryAttributes {
 	def none(): QueryAttributes = QueryAttributes(None, DBDefinition(None, None), None, Some(1000))
-} 
+}
+
+case class MaxFieldSize(value: Int, leftFunction: Option[String])

--- a/src/main/scala/dbtarzan/db/QueryAttributes.scala
+++ b/src/main/scala/dbtarzan/db/QueryAttributes.scala
@@ -17,4 +17,4 @@ object QueryAttributes {
 	def none(): QueryAttributes = QueryAttributes(None, DBDefinition(None, None), None, Some(1000))
 }
 
-case class MaxFieldSize(value: Int, leftFunction: Option[String])
+case class MaxFieldSize(value: Int, lefSQLFunction: Option[String])

--- a/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
+++ b/src/main/scala/dbtarzan/db/actor/DatabaseActor.scala
@@ -88,10 +88,10 @@ class DatabaseActor(
 
 
   private def queryRows(qry: QueryRows) : Unit = coreHandler.withCore(qry.queryId, core => {
-    val sql = SqlBuilder.buildQuerySql(qry.structure)
+    val sql = SqlBuilder.buildQuerySql(qry.structure, core.attributes.maxFieldSize )
     val maxRows = core.limits.maxRows.getOrElse(500)
     val queryTimeouts = calcQueryTimeouts(core)
-    core.queryLoader.query(sql, maxRows, queryTimeouts, core.attributes.maxFieldSize, qry.structure.columns, rows =>
+    core.queryLoader.query(sql, maxRows, queryTimeouts, core.attributes.maxFieldSize.map(_.value), qry.structure.columns, rows =>
         guiActor ! ResponseRows(qry.queryId, qry.structure, rows)
       )
   }, e => queryRowsHandleErr(qry, e))

--- a/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
+++ b/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
@@ -23,7 +23,7 @@ object SqlBuilder {
     def extractFieldNameSubstring(textApplier: TextLeftApplier)(field: Field): String =
       if(field.fieldType == FieldType.STRING )  textApplier.replaceColumnName(field.name) else field.name
     val extractFieldName: Field => String = maxFieldSize match {
-      case Some(m) => m.leftFunction match {
+      case Some(m) => m.lefSQLFunction match {
         case Some(l) => extractFieldNameSubstring(TextLeftApplier(l, m.value))
         case None => extractFieldNameNoSubstring
       }

--- a/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
+++ b/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
@@ -5,21 +5,37 @@ import dbtarzan.db.*
 
 
 object SqlBuilder {
-  val selectClause = "SELECT * FROM "
+
   val countClause = "SELECT COUNT(*) FROM "
 
   /* builds the SQL to query the table from the (potential) original foreign key (to know which rows it has to show), the potential where filter and the table name */
-  def buildQuerySql(structure: DBTableStructure) : QuerySql = {
+  def buildQuerySql(structure: DBTableStructure, maxFieldSize: Option[MaxFieldSize]) : QuerySql = {
     val foreignClosure = buildForeignClosure(structure)
     val filters = buildFilters(structure, foreignClosure)
     val delimitedTableNameWithSchema = buildTableName(structure.attributes, structure.description.name)
     val orderBy: String = structure.orderByFields.map(SqlPartsBuilder.buildOrderBy).getOrElse("")
-    QuerySql(selectClause + delimitedTableNameWithSchema + SqlPartsBuilder.buildFilters(filters) + orderBy)
+    val selectClause: String = buildSqlClause(structure, maxFieldSize)
+    QuerySql(s"SELECT $selectClause FROM $delimitedTableNameWithSchema ${SqlPartsBuilder.buildFilters(filters)} $orderBy")
+  }
+
+  private def buildSqlClause(structure: DBTableStructure, maxFieldSize: Option[MaxFieldSize]): String = {
+    def extractFieldNameNoSubstring(field: Field): String = field.name
+    def extractFieldNameSubstring(textApplier: TextLeftApplier)(field: Field): String =
+      if(field.fieldType == FieldType.STRING )  textApplier.replaceColumnName(field.name) else field.name
+    val extractFieldName: Field => String = maxFieldSize match {
+      case Some(m) => m.leftFunction match {
+        case Some(l) => extractFieldNameSubstring(TextLeftApplier(l, m.value))
+        case None => extractFieldNameNoSubstring
+      }
+      case None => extractFieldNameNoSubstring
+    }
+    structure.columns.fields.map(extractFieldName).mkString(", ")
   }
 
   def buildSingleRowSql(structure: DBRowStructure) : QuerySql = {
     val delimitedTableNameWithSchema = buildTableName(structure.attributes, structure.tableName)
     val sqlFieldBuilder = new SqlFieldBuilder(structure.columns.fields, structure.attributes)
+    val selectClause = "SELECT * FROM "
     QuerySql(selectClause + delimitedTableNameWithSchema + SqlPartsBuilder.buildFilters(structure.filter.map(sqlFieldBuilder.buildFieldText)))
   }
 

--- a/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
+++ b/src/main/scala/dbtarzan/db/sql/SqlBuilder.scala
@@ -28,7 +28,7 @@ object SqlBuilder {
     def extractFieldNameSubstring(textApplier: TextLeftApplier)(field: Field): String =
       if(field.fieldType == FieldType.STRING )  textApplier.replaceColumnName(field.name) else field.name
     val extractFieldName: Field => String = maxFieldSize match {
-      case Some(m) => m.lefSQLFunction match {
+      case Some(m) => m.leftSQLFunction match {
         case Some(l) => extractFieldNameSubstring(TextLeftApplier(l, m.value))
         case None => extractFieldNameNoSubstring
       }

--- a/src/main/scala/dbtarzan/db/sql/SqlPartsBuilder.scala
+++ b/src/main/scala/dbtarzan/db/sql/SqlPartsBuilder.scala
@@ -5,7 +5,7 @@ import dbtarzan.db.{DBEnumsText, FieldType, FieldValue, FieldWithValue, OrderByF
 object SqlPartsBuilder {
   def buildFilters(filters : List[String]) : String = {
     if(filters.nonEmpty)
-      filters.mkString(" WHERE (\n",
+      filters.mkString("WHERE (\n",
         ") AND (\n"
         , ")")
     else
@@ -17,7 +17,7 @@ object SqlPartsBuilder {
 
   def buildOrderBy(orderByFields: OrderByFields) : String = 
     if (orderByFields.fields.nonEmpty)
-      " ORDER BY " + orderByFields.fields.map(buildOrderByOne).mkString(", ")
+      "ORDER BY " + orderByFields.fields.map(buildOrderByOne).mkString(", ")
     else
       ""
 

--- a/src/main/scala/dbtarzan/db/sql/TextLeftApplier.scala
+++ b/src/main/scala/dbtarzan/db/sql/TextLeftApplier.scala
@@ -1,0 +1,8 @@
+package dbtarzan.db.sql
+
+class TextLeftApplier(leftFunctionText: String, maxFieldSize: Int) {
+  val leftFunctionTextMaxReplaced = leftFunctionText.replace("$max", maxFieldSize.toString)
+  
+  def replaceColumnName(columnName: String): String =
+    leftFunctionTextMaxReplaced.replace("$column", columnName)  
+}

--- a/src/main/scala/dbtarzan/gui/BrowsingTable.scala
+++ b/src/main/scala/dbtarzan/gui/BrowsingTable.scala
@@ -28,7 +28,7 @@ class BrowsingTable(dbActor : ActorRef, guiActor : ActorRef, structure : DBTable
   private val foreignKeyList = new ForeignKeyListWithFilter(queryId, dbActor, log, localization)
   private val foreignKeyListWithTitle = JFXUtil.withTitle(foreignKeyList.control, localization.foreignKeys) 
   private val columnsTable = new ColumnsTable(structure.columns, localization)
-  private val queryInfo = new QueryInfo(SqlBuilder.buildQuerySql(structure), localization, () => {
+  private val queryInfo = new QueryInfo(SqlBuilder.buildQuerySql(structure, None), localization, () => {
     dbActor ! QueryRowsNumber(queryId, structure : DBTableStructure)
   })
   private val indexInfo = new IndexesInfo(localization)

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -3,7 +3,6 @@ package dbtarzan.gui.config.connections
 import dbtarzan.gui.interfaces.TControlBuilder
 import scalafx.Includes.*
 import scalafx.collections.ObservableBuffer
-import scalafx.event.ActionEvent
 import scalafx.scene.Parent
 import scalafx.scene.control.{ComboBox, ListCell}
 
@@ -39,7 +38,6 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
 
   def retrieveLeftFunction() : Option[String] = {
     val text = cmbDeLeftFunction.value.value
-    println(s"retrieveLeftFunction Text: $text")
     if(!text.isBlank)
       Some(text)
     else
@@ -49,8 +47,9 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
   def control : Parent = cmbDeLeftFunction
 
   def onChanged(useLeftFunction : () => Unit) : Unit = {
-    // cmbDeLeftFunction.onAction = (_: ActionEvent) => useLeftFunction()
-    cmbDeLeftFunction.editor.value.textProperty().onChange((_, _, _) => { cmbDeLeftFunction.value.value = cmbDeLeftFunction.editor.value.text(); useLeftFunction() })
+    cmbDeLeftFunction.editor.value.textProperty().onChange(
+      (_, _, _) => { cmbDeLeftFunction.value.value = cmbDeLeftFunction.editor.value.text(); useLeftFunction() }
+    )
   }
 }
 

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -10,7 +10,7 @@ import scalafx.scene.control.{ComboBox, ListCell}
 
 
 /* A combo box from which to select the identfier delimiters that get stored in the configuration file */
-class ComboMaxFieldSize() extends TControlBuilder with TCombo {
+class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
   private val leftFunctions : ObservableBuffer[String] = ObservableBuffer.from(List(
     "LEFT($column, $max)",
     "SUBSTR($column, 1, $max)",

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -1,6 +1,5 @@
 package dbtarzan.gui.config.connections
 
-import dbtarzan.db.{IdentifierDelimiters, IdentifierDelimitersValues}
 import dbtarzan.gui.interfaces.TControlBuilder
 import scalafx.Includes.*
 import scalafx.collections.ObservableBuffer
@@ -37,7 +36,8 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
   }
 
   def retrieveLeftFunction() : Option[String] = {
-    val text = cmbDeLeftFunction.getEditor.getText()
+    val text = cmbDeLeftFunction.value.value
+    println(s"retrieveLeftFunction Text: $text")
     if(!text.isBlank)
       Some(text)
     else
@@ -46,8 +46,9 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
 
   def control : Parent = cmbDeLeftFunction
 
-  def onChanged(useDelimiters : () => Unit) : Unit = {
-    cmbDeLeftFunction.onAction = (_: ActionEvent) => useDelimiters()
+  def onChanged(useLeftFunction : () => Unit) : Unit = {
+    // cmbDeLeftFunction.onAction = (_: ActionEvent) => useLeftFunction()
+    cmbDeLeftFunction.editor.value.textProperty().onChange((_, _, _) => { cmbDeLeftFunction.value.value = cmbDeLeftFunction.editor.value.text(); useLeftFunction() })
   }
 }
 

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -31,7 +31,6 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
 
 
   def show(leftFunction : String) : Unit = {
-    println(f"show $leftFunction")
     cmbDeLeftFunction.value = leftFunction
     cmbDeLeftFunction.editor.value.text = leftFunction
   }

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -37,7 +37,7 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
   }
 
   def retrieveLeftFunction() : Option[String] = {
-    val text = cmbDeLeftFunction.getSelectionModel.selectedItem().trim()
+    val text = cmbDeLeftFunction.getEditor.getText()
     if(!text.isBlank)
       Some(text)
     else

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboLeftSQLFunction.scala
@@ -32,7 +32,9 @@ class ComboLeftSQLFunction() extends TControlBuilder with TCombo {
 
 
   def show(leftFunction : String) : Unit = {
+    println(f"show $leftFunction")
     cmbDeLeftFunction.value = leftFunction
+    cmbDeLeftFunction.editor.value.text = leftFunction
   }
 
   def retrieveLeftFunction() : Option[String] = {

--- a/src/main/scala/dbtarzan/gui/config/connections/ComboMaxFieldSize.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ComboMaxFieldSize.scala
@@ -1,0 +1,53 @@
+package dbtarzan.gui.config.connections
+
+import dbtarzan.db.{IdentifierDelimiters, IdentifierDelimitersValues}
+import dbtarzan.gui.interfaces.TControlBuilder
+import scalafx.Includes.*
+import scalafx.collections.ObservableBuffer
+import scalafx.event.ActionEvent
+import scalafx.scene.Parent
+import scalafx.scene.control.{ComboBox, ListCell}
+
+
+/* A combo box from which to select the identfier delimiters that get stored in the configuration file */
+class ComboMaxFieldSize() extends TControlBuilder with TCombo {
+  private val leftFunctions : ObservableBuffer[String] = ObservableBuffer.from(List(
+    "LEFT($column, $max)",
+    "SUBSTR($column, 1, $max)",
+    "SUBSTRING($column FROM 1 FOR $max)"
+  ))
+  private val cmbDeLeftFunction = new ComboBox[String] {
+    items = leftFunctions
+    editable = true
+    value = ""
+    cellFactory = (cell, value) => {
+      cell.text.value = value
+    }
+    buttonCell = buildCell()
+  }
+ 
+  private def buildCell() = new ListCell[String] {
+    item.onChange { (_ , _, newValue) => {
+        text.value = newValue
+      }}}
+
+
+  def show(leftFunction : String) : Unit = {
+    cmbDeLeftFunction.value = leftFunction
+  }
+
+  def retrieveLeftFunction() : Option[String] = {
+    val text = cmbDeLeftFunction.getSelectionModel.selectedItem().trim()
+    if(!text.isBlank)
+      Some(text)
+    else
+      None
+  }
+
+  def control : Parent = cmbDeLeftFunction
+
+  def onChanged(useDelimiters : () => Unit) : Unit = {
+    cmbDeLeftFunction.onAction = (_: ActionEvent) => useDelimiters()
+  }
+}
+

--- a/src/main/scala/dbtarzan/gui/config/connections/ConnectionDataValidation.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/ConnectionDataValidation.scala
@@ -23,7 +23,7 @@ object ConnectionDataValidation
       // errorIf("Password cannot contain spaces", _ => Validation.containsWhtitespace(data.password)),
       errorIf("Empty jar", _ => data.jar.isEmpty),
       errorIf("Jar cannot contain spaces", _ => Validation.containsWhitespace(data.jar)),
-      errorIf("Max field size should be over "+MAXFIELDSIZE_MIN, _ => !Validation.isMoreThanOrNone(data.maxFieldSize, MAXFIELDSIZE_MIN))
+      errorIf("Max field size should be over "+MAXFIELDSIZE_MIN, _ => !Validation.isMoreThanOrNone(data.maxFieldSize.map(_.value), MAXFIELDSIZE_MIN))
     ).flatten
 
   private def errorIf(errorText: String, conditionForError: String => Boolean): Option[String] = {

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -57,8 +57,8 @@ class OneConnectionEditor(
   private val txtQueryTimeoutInSeconds = JFXUtil.numTextField()
   private val txtMaxFieldSizeValue = JFXUtil.numTextField()
 
-  private val comboMaxFieldSize = ComboMaxFieldSize()
-  
+  private val comboLeftSqlFunction = ComboLeftSQLFunction()
+  txtMaxFieldSizeValue.text.onChange((_, _, newValue) => JFXUtil.changeControlsVisibility(newValue.nonEmpty , comboLeftSqlFunction.control))
   
   private val chkInClause = new CheckBox {
     selected.onChange((_, _, newValue) => txtMaxInClauseCount.disable = !newValue)
@@ -71,6 +71,7 @@ class OneConnectionEditor(
   private val lblMaxRows = new Label { text = localization.maxRows+":" }
   private val lblQueryTimeoutInSeconds = new Label { text = localization.queryTimeoutInSeconds+":" }
   private val lblMaxFieldSize = new Label { text = localization.maxFieldSize+":" }
+  private val lblLeftSqlFunction = new Label {text = localization.leftSQLFunction + ":"}
   private val lblUseInClause = new Label { text = localization.useInClause+":" }
   private val lblMaxInClauseCount = new Label { text = localization.maxInClauseCount+":" }
   private val lblCatalog = new Label { text = localization.catalog+":" }
@@ -111,14 +112,16 @@ class OneConnectionEditor(
     add(lblQueryTimeoutInSeconds, 0, 10)
     add(HBox(txtQueryTimeoutInSeconds), 1, 10)
     add(lblMaxFieldSize, 0, 11)
-    add(HBox(20.0, txtMaxFieldSizeValue, comboMaxFieldSize.control), 1, 11)
-    add(lblUseInClause, 0, 12)
-    add(chkInClause, 1, 12)
-    add(lblMaxInClauseCount, 0, 13)
-    add(HBox(txtMaxInClauseCount), 1, 13)
-    add(lblCatalog, 0, 14)
-    add(txtCatalog, 1, 14)
-    add(linkToJdbcUrls, 1, 15)
+    add(HBox(txtMaxFieldSizeValue), 1, 11)
+    add(lblLeftSqlFunction, 0, 12)
+    add(HBox(comboLeftSqlFunction.control), 1, 12)
+    add(lblUseInClause, 0, 13)
+    add(chkInClause, 1, 13)
+    add(lblMaxInClauseCount, 0, 14)
+    add(HBox(txtMaxInClauseCount), 1, 14)
+    add(lblCatalog, 0, 15)
+    add(txtCatalog, 1, 15)
+    add(linkToJdbcUrls, 1, 16)
     GridPane.setHalignment(linkToJdbcUrls, HPos.Right)
     padding = Insets(10)
     vgap = 10
@@ -169,7 +172,8 @@ class OneConnectionEditor(
       txtQueryTimeoutInSeconds,
       lblMaxFieldSize,
       txtMaxFieldSizeValue,
-      comboMaxFieldSize.control,
+      lblLeftSqlFunction,
+      comboLeftSqlFunction.control,
       lblUseInClause,
       chkInClause,
       lblMaxInClauseCount,
@@ -199,7 +203,7 @@ class OneConnectionEditor(
         cmbDelimiters.retrieveDelimiters(),
         txtMaxRows.toOptInt,
         txtQueryTimeoutInSeconds.toOptInt,
-        txtMaxFieldSizeValue.toOptInt.map(fs => MaxFieldSize(fs, comboMaxFieldSize.retrieveLeftFunction())),
+        txtMaxFieldSizeValue.toOptInt.map(fs => MaxFieldSize(fs, comboLeftSqlFunction.retrieveLeftFunction())),
         inClauseToData(),
         StringUtil.emptyToNone(txtCatalog.text())
     )

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -154,7 +154,7 @@ class OneConnectionEditor(
     txtMaxRows.fromOptInt(data.maxRows)
     txtQueryTimeoutInSeconds.fromOptInt(data.queryTimeoutInSeconds)
     txtMaxFieldSizeValue.fromOptInt(data.maxFieldSize.map(_.value))
-    cmbLeftSqlFunction.show(data.maxFieldSize.map(_.lefSQLFunction.getOrElse("")).getOrElse(""))
+    cmbLeftSqlFunction.show(data.maxFieldSize.map(_.leftSQLFunction.getOrElse("")).getOrElse(""))
     chkInClause.selected = data.maxInClauseCount.isDefined
     txtMaxInClauseCount.fromOptInt(data.maxInClauseCount)
     txtMaxInClauseCount.disable = data.maxInClauseCount.isEmpty

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -107,15 +107,15 @@ class OneConnectionEditor(
     add(lblDelimiters, 0, 8)
     add(cmbDelimiters.control, 1, 8)
     add(lblMaxRows, 0, 9)
-    add(new HBox { children = List(txtMaxRows)}, 1, 9)
+    add(HBox(txtMaxRows), 1, 9)
     add(lblQueryTimeoutInSeconds, 0, 10)
-    add(new HBox { children = List(txtQueryTimeoutInSeconds)}, 1, 10)
+    add(HBox(txtQueryTimeoutInSeconds), 1, 10)
     add(lblMaxFieldSize, 0, 11)
-    add(new HBox { children = List(txtMaxFieldSizeValue, comboMaxFieldSize.control)}, 1, 11)
+    add(HBox(20.0, txtMaxFieldSizeValue, comboMaxFieldSize.control), 1, 11)
     add(lblUseInClause, 0, 12)
     add(chkInClause, 1, 12)
     add(lblMaxInClauseCount, 0, 13)
-    add(new HBox { children = List(txtMaxInClauseCount)}, 1, 13)
+    add(HBox(txtMaxInClauseCount), 1, 13)
     add(lblCatalog, 0, 14)
     add(txtCatalog, 1, 14)
     add(linkToJdbcUrls, 1, 15)
@@ -169,6 +169,7 @@ class OneConnectionEditor(
       txtQueryTimeoutInSeconds,
       lblMaxFieldSize,
       txtMaxFieldSizeValue,
+      comboMaxFieldSize.control,
       lblUseInClause,
       chkInClause,
       lblMaxInClauseCount,

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -57,8 +57,8 @@ class OneConnectionEditor(
   private val txtQueryTimeoutInSeconds = JFXUtil.numTextField()
   private val txtMaxFieldSizeValue = JFXUtil.numTextField()
 
-  private val comboLeftSqlFunction = ComboLeftSQLFunction()
-  txtMaxFieldSizeValue.text.onChange((_, _, newValue) => JFXUtil.changeControlsVisibility(newValue.nonEmpty , comboLeftSqlFunction.control))
+  private val cmbLeftSqlFunction = ComboLeftSQLFunction()
+  txtMaxFieldSizeValue.text.onChange((_, _, newValue) => JFXUtil.changeControlsVisibility(newValue.nonEmpty , cmbLeftSqlFunction.control))
   
   private val chkInClause = new CheckBox {
     selected.onChange((_, _, newValue) => txtMaxInClauseCount.disable = !newValue)
@@ -114,7 +114,7 @@ class OneConnectionEditor(
     add(lblMaxFieldSize, 0, 11)
     add(HBox(txtMaxFieldSizeValue), 1, 11)
     add(lblLeftSqlFunction, 0, 12)
-    add(HBox(comboLeftSqlFunction.control), 1, 12)
+    add(HBox(cmbLeftSqlFunction.control), 1, 12)
     add(lblUseInClause, 0, 13)
     add(chkInClause, 1, 13)
     add(lblMaxInClauseCount, 0, 14)
@@ -173,7 +173,7 @@ class OneConnectionEditor(
       lblMaxFieldSize,
       txtMaxFieldSizeValue,
       lblLeftSqlFunction,
-      comboLeftSqlFunction.control,
+      cmbLeftSqlFunction.control,
       lblUseInClause,
       chkInClause,
       lblMaxInClauseCount,
@@ -203,7 +203,7 @@ class OneConnectionEditor(
         cmbDelimiters.retrieveDelimiters(),
         txtMaxRows.toOptInt,
         txtQueryTimeoutInSeconds.toOptInt,
-        txtMaxFieldSizeValue.toOptInt.map(fs => MaxFieldSize(fs, comboLeftSqlFunction.retrieveLeftFunction())),
+        txtMaxFieldSizeValue.toOptInt.map(fs => MaxFieldSize(fs, cmbLeftSqlFunction.retrieveLeftFunction())),
         inClauseToData(),
         StringUtil.emptyToNone(txtCatalog.text())
     )
@@ -241,7 +241,8 @@ class OneConnectionEditor(
     jarSelector.onChange(safe.onChange(() => useData(toData)))
     List(
       cmbDelimiters,
-      cmbSchemas
+      cmbSchemas,
+      cmbLeftSqlFunction,
     ).foreach(_.onChanged(() => safe.onChange(() => useData(toData))))
   }
 

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -154,6 +154,7 @@ class OneConnectionEditor(
     txtMaxRows.fromOptInt(data.maxRows)
     txtQueryTimeoutInSeconds.fromOptInt(data.queryTimeoutInSeconds)
     txtMaxFieldSizeValue.fromOptInt(data.maxFieldSize.map(_.value))
+    cmbLeftSqlFunction.show(data.maxFieldSize.map(_.lefSQLFunction.getOrElse("")).getOrElse(""))
     chkInClause.selected = data.maxInClauseCount.isDefined
     txtMaxInClauseCount.fromOptInt(data.maxInClauseCount)
     txtMaxInClauseCount.disable = data.maxInClauseCount.isEmpty

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -111,7 +111,7 @@ class OneConnectionEditor(
     add(lblQueryTimeoutInSeconds, 0, 10)
     add(new HBox { children = List(txtQueryTimeoutInSeconds)}, 1, 10)
     add(lblMaxFieldSize, 0, 11)
-    add(new HBox { children = List(txtMaxFieldSizeValue)}, 1, 11)
+    add(new HBox { children = List(txtMaxFieldSizeValue, comboMaxFieldSize.control)}, 1, 11)
     add(lblUseInClause, 0, 12)
     add(chkInClause, 1, 12)
     add(lblMaxInClauseCount, 0, 13)

--- a/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
+++ b/src/main/scala/dbtarzan/gui/config/connections/OneConnectionEditor.scala
@@ -5,11 +5,11 @@ import scalafx.scene.layout.{ColumnConstraints, GridPane, HBox, Priority}
 import scalafx.scene.Parent
 import scalafx.event.ActionEvent
 import scalafx.geometry.{HPos, Insets}
-import scalafx.Includes._
+import scalafx.Includes.*
 import dbtarzan.gui.util.{JFXUtil, OnChangeSafe, StringUtil}
 import dbtarzan.config.connections.ConnectionData
 import dbtarzan.config.password.{EncryptionKey, Password, PasswordEncryption}
-import dbtarzan.db.SchemaName
+import dbtarzan.db.{MaxFieldSize, SchemaName}
 import dbtarzan.gui.OpenWeb
 import dbtarzan.gui.interfaces.TControlBuilder
 import dbtarzan.localization.Localization
@@ -55,10 +55,15 @@ class OneConnectionEditor(
   private val cmbDelimiters = new ComboDelimiters()
   private val txtMaxRows = JFXUtil.numTextField()
   private val txtQueryTimeoutInSeconds = JFXUtil.numTextField()
-  private val txtMaxFieldSize = JFXUtil.numTextField()
+  private val txtMaxFieldSizeValue = JFXUtil.numTextField()
+
+  private val comboMaxFieldSize = ComboMaxFieldSize()
+  
+  
   private val chkInClause = new CheckBox {
     selected.onChange((_, _, newValue) => txtMaxInClauseCount.disable = !newValue)
   }
+  
   private val txtMaxInClauseCount = JFXUtil.numTextField()
 
 
@@ -106,7 +111,7 @@ class OneConnectionEditor(
     add(lblQueryTimeoutInSeconds, 0, 10)
     add(new HBox { children = List(txtQueryTimeoutInSeconds)}, 1, 10)
     add(lblMaxFieldSize, 0, 11)
-    add(new HBox { children = List(txtMaxFieldSize)}, 1, 11)
+    add(new HBox { children = List(txtMaxFieldSizeValue)}, 1, 11)
     add(lblUseInClause, 0, 12)
     add(chkInClause, 1, 12)
     add(lblMaxInClauseCount, 0, 13)
@@ -145,7 +150,7 @@ class OneConnectionEditor(
     cmbDelimiters.show(data.identifierDelimiters)
     txtMaxRows.fromOptInt(data.maxRows)
     txtQueryTimeoutInSeconds.fromOptInt(data.queryTimeoutInSeconds)
-    txtMaxFieldSize.fromOptInt(data.maxFieldSize)
+    txtMaxFieldSizeValue.fromOptInt(data.maxFieldSize.map(_.value))
     chkInClause.selected = data.maxInClauseCount.isDefined
     txtMaxInClauseCount.fromOptInt(data.maxInClauseCount)
     txtMaxInClauseCount.disable = data.maxInClauseCount.isEmpty
@@ -163,7 +168,7 @@ class OneConnectionEditor(
       lblQueryTimeoutInSeconds,
       txtQueryTimeoutInSeconds,
       lblMaxFieldSize,
-      txtMaxFieldSize,
+      txtMaxFieldSizeValue,
       lblUseInClause,
       chkInClause,
       lblMaxInClauseCount,
@@ -193,7 +198,7 @@ class OneConnectionEditor(
         cmbDelimiters.retrieveDelimiters(),
         txtMaxRows.toOptInt,
         txtQueryTimeoutInSeconds.toOptInt,
-        txtMaxFieldSize.toOptInt,
+        txtMaxFieldSizeValue.toOptInt.map(fs => MaxFieldSize(fs, comboMaxFieldSize.retrieveLeftFunction())),
         inClauseToData(),
         StringUtil.emptyToNone(txtCatalog.text())
     )
@@ -222,7 +227,7 @@ class OneConnectionEditor(
       txtPassword.text,
       txtMaxRows.text,
       txtQueryTimeoutInSeconds.text,
-      txtMaxFieldSize.text,
+      txtMaxFieldSizeValue.text,
       txtMaxInClauseCount.text,
       txtCatalog.text,
       chkPassword.selected,

--- a/src/main/scala/dbtarzan/localization/English.scala
+++ b/src/main/scala/dbtarzan/localization/English.scala
@@ -28,6 +28,7 @@ class English extends Localization {
     def maxRows = "Max Rows"
     def queryTimeoutInSeconds = "Query timeout in seconds"
     def maxFieldSize = "Max field size"
+    def leftSQLFunction = "LEFT SQL function"
     def useInClause = "Use in clause"
     def maxInClauseCount = "Max in clause count"
     def tables = "Tables"

--- a/src/main/scala/dbtarzan/localization/Italian.scala
+++ b/src/main/scala/dbtarzan/localization/Italian.scala
@@ -28,6 +28,7 @@ class Italian extends Localization {
     def maxRows = "Max Righe"    
     def queryTimeoutInSeconds = "Timeout query in secondi"
     def maxFieldSize = "Max dimensione campo"
+    def leftSQLFunction = "Funzione SQL LEFT"
     def useInClause = "Usa in clause"
     def maxInClauseCount = "Max numero elementi in clause"
     def tables = "Tabelle"

--- a/src/main/scala/dbtarzan/localization/Localization.scala
+++ b/src/main/scala/dbtarzan/localization/Localization.scala
@@ -28,6 +28,7 @@ trait Localization {
   def maxRows : String
   def queryTimeoutInSeconds : String
   def maxFieldSize: String
+  def leftSQLFunction: String
   def useInClause: String
   def maxInClauseCount: String
   def tables: String

--- a/src/main/scala/dbtarzan/localization/Spanish.scala
+++ b/src/main/scala/dbtarzan/localization/Spanish.scala
@@ -27,6 +27,7 @@ class Spanish extends Localization {
     def delimiters = "Separadores"
     def maxRows = "Máximo de filas"
     def maxFieldSize = "Max tamaño campo"
+    def leftSQLFunction = "Función SQL LEFT"
     def useInClause = "Usa in clause"
     def maxInClauseCount = "Número máximo de elementos in clause"
     def queryTimeoutInSeconds = "tiempo de espera de consulta en segundos"

--- a/src/test/scala/dbtarzan/db/DBTableStructureBuilder.scala
+++ b/src/test/scala/dbtarzan/db/DBTableStructureBuilder.scala
@@ -25,8 +25,6 @@ object DBTableStructureBuilder {
 
   def tableName: String = "customer"
 
-  def noFields(): Fields = Fields(List())
-
   def buildRow(name: String, age: String): FKRow = FKRow(buildFields(name, age))
 
   def buildAttributes(): QueryAttributes =

--- a/src/test/scala/dbtarzan/db/IntegrationTest.scala
+++ b/src/test/scala/dbtarzan/db/IntegrationTest.scala
@@ -92,8 +92,8 @@ class IntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val structure = DBTableStructure(
         TableDescription("pc", None, None),
         Fields(
-          List(FieldType.INT, FieldType.INT, FieldType.INT, FieldType.INT, FieldType.FLOAT, FieldType.STRING, FieldType.FLOAT)
-            .map(t => Field("x", t, ""))
+          List(Field("code", FieldType.INT, ""), Field("model", FieldType.INT, ""), Field("speed", FieldType.INT, ""),
+            Field("ram", FieldType.INT, ""), Field("hd", FieldType.FLOAT, ""), Field("cd", FieldType.STRING, ""), Field("price", FieldType.FLOAT, ""))
           ),
         Some(
           ForeignKeyCriteria(List(FKRow(List(FieldWithValue("model", "1232")))), List(Field("model",  FieldType.STRING, "")))
@@ -113,7 +113,7 @@ class IntegrationTest extends AnyFlatSpec with BeforeAndAfter {
   "query of PC" should "give the no more rows than the limit" in {
     val structure = DBTableStructure(
         TableDescription("pc", None, None),
-        noFields(),
+        Fields(List(Field("code", FieldType.INT, ""), Field("model", FieldType.STRING, ""))),
         None,
         None,
         None,

--- a/src/test/scala/dbtarzan/db/IntegrationTest.scala
+++ b/src/test/scala/dbtarzan/db/IntegrationTest.scala
@@ -92,7 +92,8 @@ class IntegrationTest extends AnyFlatSpec with BeforeAndAfter {
     val structure = DBTableStructure(
         TableDescription("pc", None, None),
         Fields(
-          List(FieldType.INT, FieldType.INT, FieldType.INT, FieldType.INT, FieldType.FLOAT, FieldType.STRING, FieldType.FLOAT).map(t => Field("x", t, ""))
+          List(FieldType.INT, FieldType.INT, FieldType.INT, FieldType.INT, FieldType.FLOAT, FieldType.STRING, FieldType.FLOAT)
+            .map(t => Field("x", t, ""))
           ),
         Some(
           ForeignKeyCriteria(List(FKRow(List(FieldWithValue("model", "1232")))), List(Field("model",  FieldType.STRING, "")))

--- a/src/test/scala/dbtarzan/db/IntegrationTest.scala
+++ b/src/test/scala/dbtarzan/db/IntegrationTest.scala
@@ -103,7 +103,7 @@ class IntegrationTest extends AnyFlatSpec with BeforeAndAfter {
           ))),
         QueryAttributes.none()
     )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     var rows : Rows = Rows(List())
     new QueryLoader(connection, new FakeLogger()).query(sql, 500, 10 seconds, None, structure.columns, rs => rows = rs)
     assert(Rows(List(Row(List(1, 1232, 500, 64, 5.0, "12x", 600.0)), Row(List(7, 1232, 500, 32, 10.0, "12x", 400.0))))  === rows)
@@ -118,7 +118,7 @@ class IntegrationTest extends AnyFlatSpec with BeforeAndAfter {
         None,
         QueryAttributes.none()
       )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     var rows : Rows = Rows(List())
     new QueryLoader(connection, new FakeLogger()).query(sql, 3, 10 seconds, None, structure.columns, rs => rows = rs)
     assert(3  === rows.rows.length)

--- a/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
+++ b/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
@@ -15,7 +15,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         None,
         QueryAttributes.none()
       )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM customer" === sql.sql)
   }
 
@@ -28,7 +28,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         None,
         DBTableStructureBuilder.buildAttributes()
         )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM [TST].[customer]" === sql.sql)
   }
 
@@ -41,7 +41,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         None,
         QueryAttributes.none()
       )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM customer WHERE (\n(name='John' AND age=23))" === sql.sql)
   }
 
@@ -54,7 +54,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         None,
         QueryAttributes.none()
       )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM customer WHERE (\nname = 'john')" === sql.sql)
   }
 
@@ -67,7 +67,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         Some(DBTableStructureBuilder.buildOrderByFields()),
         QueryAttributes.none()
     )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM customer ORDER BY name ASC, age DESC" === sql.sql)
   }
 
@@ -80,7 +80,7 @@ class SqlBuilderTest extends AnyFlatSpec {
         Some(OrderByFields(List.empty[OrderByField])),
         QueryAttributes.none()
       )
-    val sql = SqlBuilder.buildQuerySql(structure)
+    val sql = SqlBuilder.buildQuerySql(structure, None)
     assert("SELECT * FROM customer" === sql.sql)
   }
 

--- a/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
+++ b/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
@@ -9,80 +9,83 @@ class SqlBuilderTest extends AnyFlatSpec {
   "a simple table" should "give a simple query" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         None,
         None,
         None,
         QueryAttributes.none()
       )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM customer" === sql.sql)
+    assert("SELECT id, name, age FROM customer" === sql.sql)
   }
 
   "a simple table with delimiters" should "give a query with delimiters" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         None,
         None,
         None,
         DBTableStructureBuilder.buildAttributes()
         )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM [TST].[customer]" === sql.sql)
+    assert("SELECT id, name, age FROM [TST].[customer]" === sql.sql)
   }
 
   "a table with foreign criteria" should "give a query with a where clause" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         Some(DBTableStructureBuilder.buildForeignKeyCriteria()),
         None,
         None,
         QueryAttributes.none()
       )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM customer WHERE (\n(name='John' AND age=23))" === sql.sql)
+    assert("SELECT id, name, age FROM customer WHERE (\n(name='John' AND age=23))" === sql.sql)
   }
 
   "a table with additional filter" should "give a query with a where clause" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         None,
         Some(Filter("name = 'john'")),
         None,
         QueryAttributes.none()
       )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM customer WHERE (\nname = 'john')" === sql.sql)
+    assert("SELECT id, name, age FROM customer WHERE (\nname = 'john')" === sql.sql)
   }
 
   "a table with additional order by columns" should "give a query with an order by clause" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         None,
         None,
         Some(DBTableStructureBuilder.buildOrderByFields()),
         QueryAttributes.none()
     )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM customer ORDER BY name ASC, age DESC" === sql.sql)
+    assert("SELECT id, name, age FROM customer ORDER BY name ASC, age DESC" === sql.sql)
   }
 
   "a table with empty order by columns list" should "give a simple query" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
-        DBTableStructureBuilder.noFields(),
+        sampleFields(),
         None,
         None,
         Some(OrderByFields(List.empty[OrderByField])),
         QueryAttributes.none()
       )
     val sql = SqlBuilder.buildQuerySql(structure, None)
-    assert("SELECT * FROM customer" === sql.sql)
+    assert("SELECT id, name, age FROM customer" === sql.sql)
   }
+
+  private def sampleFields(): Fields =
+    Fields(List(Field("id", FieldType.INT, "INT"), Field("name", FieldType.STRING, "VARCHAR"), Field("age", FieldType.INT, "INT")))
 
   "a row structure with no attributes" should "give a simple query" in {
     val structure = DBRowStructure(
@@ -105,6 +108,4 @@ class SqlBuilderTest extends AnyFlatSpec {
     val sql = SqlBuilder.buildSingleRowSql(structure)
     assert("SELECT * FROM [TST].[customer] WHERE (\n[name]='John') AND (\n[age]=23)" === sql.sql)
   }
-
-
 }

--- a/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
+++ b/src/test/scala/dbtarzan/db/SqlBuilderTest.scala
@@ -1,8 +1,6 @@
 package dbtarzan.db
 
-import dbtarzan.db.foreignkeys.{FKRow, ForeignKeyCriteria}
 import dbtarzan.db.sql.SqlBuilder
-import dbtarzan.testutil.TestDatabaseIds
 import org.scalatest.flatspec.AnyFlatSpec
 
 class SqlBuilderTest extends AnyFlatSpec {
@@ -32,7 +30,35 @@ class SqlBuilderTest extends AnyFlatSpec {
     assert("SELECT id, name, age FROM [TST].[customer]" === sql.sql)
   }
 
-  "a table with foreign criteria" should "give a query with a where clause" in {
+
+    "a simple table with a left sql function" should "give a query that uses the function for the strings" in {
+      val structure = DBTableStructure(
+        DBTableStructureBuilder.buildDescription(),
+        sampleFields(),
+        None,
+        None,
+        None,
+        QueryAttributes.none()
+      )
+      val sql = SqlBuilder.buildQuerySql(structure, Some(MaxFieldSize(200, Some("LEFT($column, $max)"))))
+      assert("SELECT id, LEFT(name, 200), age FROM customer" === sql.sql)
+    }
+
+  "a simple table with a substr sql function" should "give a query that uses the function for the strings" in {
+    val structure = DBTableStructure(
+      DBTableStructureBuilder.buildDescription(),
+      sampleFields(),
+      None,
+      None,
+      None,
+      QueryAttributes.none()
+    )
+    val sql = SqlBuilder.buildQuerySql(structure, Some(MaxFieldSize(200, Some("SUBSTR($column, 1, $max)"))))
+    assert("SELECT id, SUBSTR(name, 1, 200), age FROM customer" === sql.sql)
+  }
+
+
+    "a table with foreign criteria" should "give a query with a where clause" in {
     val structure = DBTableStructure(
         DBTableStructureBuilder.buildDescription(),
         sampleFields(),

--- a/src/test/scala/dbtarzan/db/SqlPartsBuilderTest.scala
+++ b/src/test/scala/dbtarzan/db/SqlPartsBuilderTest.scala
@@ -12,7 +12,7 @@ class SqlPartsBuilderTest extends AnyFlatSpec {
         OrderByField(Field("age", FieldType.INT, "the age of the person"), OrderByDirection.ASC)
       ))
     )
-    assert(" ORDER BY name DESC, age ASC" === sql)
+    assert("ORDER BY name DESC, age ASC" === sql)
   }
 
   "an order by with one field" should "give an order by clause" in {
@@ -21,7 +21,7 @@ class SqlPartsBuilderTest extends AnyFlatSpec {
         OrderByField(Field("name", FieldType.STRING, "the name of the person"), OrderByDirection.DESC),
       ))
     )
-    assert(" ORDER BY name DESC" === sql)
+    assert("ORDER BY name DESC" === sql)
   }
 
   "an order by with zeo field" should "gives an empry string" in {
@@ -38,12 +38,12 @@ class SqlPartsBuilderTest extends AnyFlatSpec {
 
   "a filter list of two filters" should "give a where clause with parens" in {
     val sql = SqlPartsBuilder.buildFilters(List("name = 'John'", "age = 27"))
-    assert(" WHERE (\nname = 'John') AND (\nage = 27)" === sql)
+    assert("WHERE (\nname = 'John') AND (\nage = 27)" === sql)
   }
 
   "a filter list of one filter" should "give a where clause with parens" in {
     val sql = SqlPartsBuilder.buildFilters(List("name = 'John'"))
-      assert(" WHERE (\nname = 'John')" === sql)
+      assert("WHERE (\nname = 'John')" === sql)
   }
 
   "a filter list of zero filter" should "give an empty string" in {

--- a/src/test/scala/dbtarzan/gui/config/ConnectionDataValidationTest.scala
+++ b/src/test/scala/dbtarzan/gui/config/ConnectionDataValidationTest.scala
@@ -2,7 +2,7 @@ package dbtarzan.gui.config
 
 import dbtarzan.config.connections.ConnectionData
 import dbtarzan.config.password.Password
-import dbtarzan.db.{IdentifierDelimiters, SchemaName}
+import dbtarzan.db.{IdentifierDelimiters, MaxFieldSize, SchemaName}
 import dbtarzan.gui.config.connections.ConnectionDataValidation
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -21,7 +21,7 @@ class ConnectionDataValidationTest extends AnyFlatSpec {
         Some(IdentifierDelimiters('[', ']')),
         Some(300),
         Some(20),
-        Some(1000),
+        Some(MaxFieldSize(1000, None)),
         Some(1000),
         None
       )
@@ -65,7 +65,7 @@ class ConnectionDataValidationTest extends AnyFlatSpec {
         None,
         None,
         None,
-        Some (100),
+        Some (MaxFieldSize(100, None)),
         Some(1000),
         None
       )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ X] The commit message follows our guidelines
- [ X Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Allows to associate a LEFT SQL function to a database. The LEFT SQL function is  applied to all text fields in the query, to avoid that very large values in these fields make the query so slow that they timeout.


* **What is the current behavior?** (You can also link to an open issue here)

There is the possibility to set a limit for the length of the text fields values, but this is applied to the value after it has been  read. This works well to prevent queries timeout in some database, but no in all of them.


* **What is the new behavior (if this is a feature change)?**
Now it is possible to limit the size of the string filed values directly in the query, before the field values are read.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No



* **Other information**:
